### PR TITLE
Add missing dependency to build stage (ssdeep-devel)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN echo "tsflags=nodocs" >> /etc/yum.conf && \
 
 # Build stage that will build required python modules
 FROM base as python-build
-RUN dnf install -y --setopt=install_weak_deps=False python39-devel python39-wheel gcc gcc-c++ git-core poppler-cpp-devel && \
+RUN dnf install -y --setopt=install_weak_deps=False python39-devel python39-wheel gcc gcc-c++ git-core poppler-cpp-devel ssdeep-devel && \
     rm -rf /var/cache/dnf
 ARG MISP_MODULES_VERSION=main
 RUN --mount=type=tmpfs,target=/tmp mkdir /tmp/source && \


### PR DESCRIPTION
I'm experiencing build issues with the `misp-modules` CentOS Stream container, which seem to be related to a missing package providing development headers for `pydeep`.

As you can see below, `pydeep` is looking for development headers for libfuzzy, which are provided by `ssdeep-devel` from EPEL.

It's a simple commit to add these to the build stage of the Dockerfile, and I've tested that adding this does fix the issue below.

```
  Building wheel for pydeep (setup.py): started
  Building wheel for pydeep (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3.9 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-wheel-rrb29abi/pydeep/setup.py'"'"'; __file__='"'"'/tmp/pip-wheel-rrb29abi/pydeep/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-d5_8smol
       cwd: /tmp/pip-wheel-rrb29abi/pydeep/
  Complete output (12 lines):
  running bdist_wheel
  running build
  running build_ext
  building 'pydeep' extension
  creating build
  creating build/temp.linux-x86_64-3.9
  gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/local/include/ -I/usr/include/python3.9 -c pydeep.c -o build/temp.linux-x86_64-3.9/pydeep.o
  pydeep.c:2:10: fatal error: fuzzy.h: No such file or directory
   #include <fuzzy.h>
            ^~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/gcc' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for pydeep
  Running setup.py clean for pydeep
  Building wheel for pytesseract (setup.py): started
  Building wheel for pytesseract (setup.py): finished with status 'done'
  Created wheel for pytesseract: filename=pytesseract-0.3.8-py2.py3-none-any.whl size=14062 sha256=b4398303218da293a024f9ee2e95a80e1be9d201f5ec6db8886e448d8dc6cf1b
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/3f/38/cf/de35347eec541f89e62bb0011764c38cbd4a82c0d532168abb
  Building wheel for python-baseconv (setup.py): started
  Building wheel for python-baseconv (setup.py): finished with status 'done'
  Created wheel for python-baseconv: filename=python_baseconv-1.2.2-py3-none-any.whl size=5498 sha256=a24712218a368f3cd8a7c207ccf306c1a35a5259320280d942d824195d611cf5
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/5a/5c/e6/ea4b6a9d54dfaea26de9aa02f2ec9a255dfd49b1928b825921
  Building wheel for python-docx (setup.py): started
  Building wheel for python-docx (setup.py): finished with status 'done'
  Created wheel for python-docx: filename=python_docx-0.8.11-py3-none-any.whl size=184601 sha256=ac43dfe328727524ebb46ffe5a847f2bec06424688b4bdf1fdaa6022e37520bc
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/83/8b/7c/09ae60c42c7ba4ed2dddaf2b8b9186cb105255856d6ed3dba5
  Building wheel for python-pptx (setup.py): started
  Building wheel for python-pptx (setup.py): finished with status 'done'
  Created wheel for python-pptx: filename=python_pptx-0.6.19-py3-none-any.whl size=470158 sha256=03c447add041b8c5381a0d11e0599c56c47faf34fd55239bb1770000e1a74175
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/e9/ca/d0/438ad5f0f698dd8f809a2ff9bb6b528735a6f4c487e809135f
  Building wheel for shodan (setup.py): started
  Building wheel for shodan (setup.py): finished with status 'done'
  Created wheel for shodan: filename=shodan-1.25.0-py3-none-any.whl size=46389 sha256=641a790fc72ecee9827da06aba4c620afb6f745ab03d0e49457f69f0578a5cb9
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/31/29/1b/0084c7003781a6a0195742da5dc6bb204239af88e9b9dc79d6
  Building wheel for socketio-client (setup.py): started
  Building wheel for socketio-client (setup.py): finished with status 'done'
  Created wheel for socketio-client: filename=socketIO_client-0.5.7.4-py3-none-any.whl size=14401 sha256=c242ae4aba6f70a916b2a2d3d652921d9c804bfd4a6318617324917406e81142
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/da/b8/d3/0e09acfcbdc77c570887488c11dc656dd2217eae45e3fb2483
  Building wheel for unicodecsv (setup.py): started
  Building wheel for unicodecsv (setup.py): finished with status 'done'
  Created wheel for unicodecsv: filename=unicodecsv-0.14.1-py3-none-any.whl size=10768 sha256=3e8bead8d4e0eb43e956da8c722f532641c2c8d20652a2017dc6cfc4a3d2de54
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/d8/c8/27/b237d3378d5c9ed25c2c63d9af1b3d5ccb99934f3dd030de87
  Building wheel for urlarchiver (setup.py): started
  Building wheel for urlarchiver (setup.py): finished with status 'done'
  Created wheel for urlarchiver: filename=urlarchiver-0.2-py3-none-any.whl size=2606 sha256=d482cad6ac395ad6af0f44a4b950b255927ba5360151b01d739f7cedcc125197
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/ce/d7/c9/34cf2cca8520c29537f26d246c6c67585275f93da9b67453fb
  Building wheel for validators (setup.py): started
  Building wheel for validators (setup.py): finished with status 'done'
  Created wheel for validators: filename=validators-0.14.0-py3-none-any.whl size=17074 sha256=fd1fe0ecd0da80b678e3ed0b43cd6ca48132c0a2d2dbdeb6772a8e54de7d8d11
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/46/85/b5/e5a80b2e12a157b313daeafb7cc35a1e6ad360d89aee972636
  Building wheel for vt-graph-api (setup.py): started
  Building wheel for vt-graph-api (setup.py): finished with status 'done'
  Created wheel for vt-graph-api: filename=vt_graph_api-1.1.2-py3-none-any.whl size=33261 sha256=a061faecd943c12340b0cb1dec2d351adfe62bcfd8fe7d7a6e7c4723065da8e7
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/52/14/eb/2be896c2f9178cecf7462e414d6cf57ca1ecb64ac4a7a979e0
  Building wheel for wrapt (setup.py): started
  Building wheel for wrapt (setup.py): finished with status 'done'
  Created wheel for wrapt: filename=wrapt-1.12.1-cp39-cp39-linux_x86_64.whl size=75833 sha256=c58e4b618b1ef66333ca3b1a7c70851badac68c0b60bd2b86e71ba2c62e85053
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/98/23/68/efe259aaca055e93b08e74fbe512819c69a2155c11ba3c0f10
  Building wheel for yara-python (setup.py): started
  Building wheel for yara-python (setup.py): finished with status 'done'
  Created wheel for yara-python: filename=yara_python-3.8.1-cp39-cp39-linux_x86_64.whl size=561285 sha256=c2f8f772c13414b5b36d6800bfd14ee96f039a06c437d44e874c75ab23cfe36f
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/27/7b/e4/3e790523bcb5b8ca49212e7830e8c825479801f1e01229eef0
  Building wheel for misp-modules (PEP 517): started
  Building wheel for misp-modules (PEP 517): finished with status 'done'
  Created wheel for misp-modules: filename=misp_modules-1.0-py3-none-any.whl size=278602 sha256=51232fbb0c8d5d8dedbd680cc52c3821b08f151d25f9777500ec7ac539c33530
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/84/ad/81/8ff46390c751762366127d7ffd2e3a4309cd41b389395bdbfe
  Building wheel for trustar (setup.py): started
  Building wheel for trustar (setup.py): finished with status 'done'
  Created wheel for trustar: filename=trustar-0.3.34-py3-none-any.whl size=80587 sha256=f58f6831c2226b5a0f16afceff0305e9cd2a6d9dd25135f1e3e2f6b7a6f25775
  Stored in directory: /tmp/pip-ephem-wheel-cache-upyduuau/wheels/fe/78/bc/8fd29b4297a4eb5a9f3a5c5552bb3accde1dbe5ede770bfe2d
Successfully built pybgpranking pyipasnhistory pyintel471 odtreader pydnstrails pyonyphe antlr4-python3-runtime blockchain colorclass compressed-rtf dnsdb2 ez-setup ezodf future json-log-formatter lark-parser maxminddb np olefile pdftotext pytesseract python-baseconv python-docx python-pptx shodan socketio-client unicodecsv urlarchiver validators vt-graph-api wrapt yara-python misp-modules trustar
Failed to build pydeep
ERROR: Failed to build one or more wheels
Error: building at STEP "RUN --mount=type=tmpfs,target=/tmp mkdir /tmp/source &&     cd /tmp/source &&     git config --system http.sslVersion tlsv1.3 &&     COMMIT=$(git ls-remote https://github.com/MISP/misp-modules.git $MISP_MODULES_VERSION | cut -f1) &&     curl --proto '=https' --tlsv1.3 --fail -sSL https://github.com/MISP/misp-modules/archive/$COMMIT.tar.gz | tar zx --strip-components=1 &&     pip3 --no-cache-dir wheel --wheel-dir /wheels -r REQUIREMENTS &&     echo $COMMIT > /misp-modules-commit": while running runtime: exit status 1
```