### PR TITLE
container: Switch to AlmaLinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base image with python3.11 and enabled powertools and epel repo
-ARG BASE_IMAGE=quay.io/centos/centos:stream8
+ARG BASE_IMAGE=almalinux:8
 FROM $BASE_IMAGE as base
 
 COPY misp-enable-epel.sh /usr/bin/
@@ -44,4 +44,4 @@ COPY sentry.py /home/misp-modules/.local/lib/python3.11/site-packages/misp_modul
 
 EXPOSE 6666/tcp
 CMD ["/home/misp-modules/.local/bin/misp-modules", "-l", "0.0.0.0"]
-HEALTHCHECK CMD curl -s -o /dev/null localhost:6666/healthcheck
+HEALTHCHECK CMD curl -s localhost:6666/healthcheck

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Then you can run container from this image:
 
 This software is licensed under GNU General Public License version 3. MISP modules is licensed under GNU Affero General Public License version 3.
 
-* Copyright (C) 2022-2024 [National Cyber and Information Security Agency of the Czech republic (NÚKIB)](https://www.nukib.cz/en/)
+* Copyright (C) 2022-2024 [National Cyber and Information Security Agency of the Czech Republic (NÚKIB)](https://nukib.gov.cz/en/) 🇨🇿

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MISP Modules
 
-Container image for [MISP modules](https://github.com/MISP/misp-modules) based on CentOS Stream 8.
+Container image for [MISP modules](https://github.com/MISP/misp-modules) based on AlmaLinux 8.
 
 This image is intended to use with [MISP](https://github.com/MISP/misp) image.
 
@@ -26,4 +26,4 @@ Then you can run container from this image:
 
 This software is licensed under GNU General Public License version 3. MISP modules is licensed under GNU Affero General Public License version 3.
 
-* Copyright (C) 2022 [National Cyber and Information Security Agency of the Czech republic (NÚKIB)](https://www.nukib.cz/en/)
+* Copyright (C) 2022-2024 [National Cyber and Information Security Agency of the Czech republic (NÚKIB)](https://www.nukib.cz/en/)


### PR DESCRIPTION
CentOS Stream 8 support ends at 31 May 2024, so we have to switch to AlmaxLinux that will be supported until 01 Mar 2029.